### PR TITLE
Add 'Read More' page functionality

### DIFF
--- a/home/templates/home/read_more.html
+++ b/home/templates/home/read_more.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+
+{% block body %}
+
+
+
+{% endblock %}

--- a/home/urls.py
+++ b/home/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='home'),
+    path('read_more/', views.index, name='read_more'),
 
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -8,3 +8,10 @@ def index(request):
     context = {}
 
     return render(request, "home/index.html", context)
+
+
+def read_more(request):
+
+    context = {}
+
+    return render(request, "home/read_more.html", context)

--- a/templates/base.html
+++ b/templates/base.html
@@ -50,7 +50,7 @@
                   <a class="nav-link" href="#">About Us</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="#">Read More</a>
+                  <a class="nav-link" href="{% url 'read_more' %}">Read More</a>
                 </li>
                   <li class="nav-item">
                   <a class="nav-link" href="{% url 'blog_home' %}">BLOG</a>


### PR DESCRIPTION
A new 'Read More' HTML template has been created under the home/templates directory. The 'Read More' option in the navigation bar of the base template is updated to link to this page. The URL mapping and corresponding view function for this page have been added to 'home/urls.py' and 'home/views.py', respectively.