### PR TITLE
Update read_more template and base stylesheet link

### DIFF
--- a/home/templates/home/read_more.html
+++ b/home/templates/home/read_more.html
@@ -1,7 +1,5 @@
 {% extends 'base.html' %}
 
 {% block body %}
-
-
-
+    <h1>test</h1>
 {% endblock %}

--- a/home/urls.py
+++ b/home/urls.py
@@ -3,6 +3,6 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='home'),
-    path('read_more/', views.index, name='read_more'),
+    path('read_more/', views.read_more, name='read_more'),
 
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,8 @@
     <meta name="author" content="NeuroSisters">
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
-    integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous"><link href="https://fonts.googleapis.com/css2?family=Cutive+Mono&family=Truculenta:opsz,wght@12..72,100..900&family=Yatra+One&display=swap" rel="stylesheet">
+    integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css2?family=Cutive+Mono&family=Truculenta:opsz,wght@12..72,100..900&family=Yatra+One&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'style.css' %}">
 
     <script src="https://kit.fontawesome.com/6131d31248.js" crossorigin="anonymous"></script>
@@ -37,7 +38,7 @@
 <body>
     <div>
         <nav class="navbar navbar-expand-lg navbar-light custom-navbar">
-            <a class="navbar-brand" href="{% url 'home' %}"><img src="/static/img/favicon/favicon.png" alt="Logo"></a>
+            <a class="navbar-brand" href="{% url 'home' %}"><img src="{% static 'img/favicon/favicon.png' %}" alt="Logo"></a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
             </button>


### PR DESCRIPTION
In this commit, the read_more.html template has been simplified and a test heading added. The stylesheet link in the base.html has been split into two separate lines for better readability. The URL pattern in home/urls.py also has been updated to point to the correct 'read_more' view.