### PR TITLE
Remove debug toolbar URL from URL settings

### DIFF
--- a/django_settings/urls.py
+++ b/django_settings/urls.py
@@ -28,6 +28,5 @@ urlpatterns = [
 
     path("ckeditor5/", include('django_ckeditor_5.urls'), name="ck_editor_5_upload_file"),
 
-    path("__debug__/", include("debug_toolbar.urls")),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,8 +94,7 @@
 {% endblock %}
 <!-- font awsome kit -->
 <script
-  src="https://kit.fontawesome.com/e6ed4f3b44.js"
-  crossorigin="anonymous"></script>
+  src="https://kit.fontawesome.com/e6ed4f3b44.js" crossorigin="anonymous"></script>
 
 <footer class="footer">
     <div class="container">


### PR DESCRIPTION
The debug toolbar URL has been removed from django_settings/urls.py to avoid exposing debug details in production. Also, in templates/base.html, Font Awesome script attributes have been merged into a single line for cleaner code.