### PR TITLE
Add post title to forms and templates, refactor post views

### DIFF
--- a/blog/forms.py
+++ b/blog/forms.py
@@ -6,7 +6,7 @@ from .models import Comment, Post
 class PostForm(forms.ModelForm):
     class Meta:
         model = Post
-        fields = ['category', 'content', ]
+        fields = ['category', 'title', 'content', ]
         widgets = {
             'content': CKEditor5Widget(attrs={"class": "django_ckeditor_5"},
                                        config_name="default")

--- a/blog/templates/blog/edit_post.html
+++ b/blog/templates/blog/edit_post.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 
 {% block body %}
-<form method="post">
+    
+
+<form method="post" action="{% url 'edit_post' post.id %}">
     {% csrf_token %}
     {{ form }}
     <button type="submit">Update Post</button>

--- a/blog/templates/blog/post_detail.html
+++ b/blog/templates/blog/post_detail.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block body %}
-
+{{ post.title }}
     <p>post detail</p>
     {{ post.content | safe | escape }}
     {% if post.author == user or user.is_staff %}

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,3 +1,5 @@
+from datetime import timezone, datetime
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, get_object_or_404
@@ -143,30 +145,18 @@ def remove_post(request, post_id):
 @login_required
 @staff_member_required
 def add_post(request):
-    """
-    Edit a post.
-
-    :param request: The HTTP request object.
-    :param post_id: The ID of the post to be edited.
-    :return: If the request method is 'POST', the function updates the content of the post with the value of 'content' from the request's POST data, saves the post, and redirects to the post detail page. Otherwise, it renders the 'blog/edit_post.html' template with the 'post' context variable.
-
-    """
-
     if request.method == 'POST':
-
         form = PostForm(request.POST)
-        post = form.save(commit=False)
-        post.author = request.user
-        post.content = request.POST.get('content', '')
-        post.save()
-        return HttpResponseRedirect(reverse('post_detail',
-                                            kwargs={'post_id': post.id}))
+        if form.is_valid():
+            post = form.save(commit=False)
+            post.author = request.user
+            post.content = request.POST.get('content', '')
+            post.updated_at = datetime.now()
+            post.save()
+        return HttpResponseRedirect(reverse('blog_home'))
     else:
         form = PostForm()
-        return render(request,
-                      'blog/add_post.html',
-                      {'form': form})
-
+        return render(request, 'blog/add_post.html', {'form': form})
 
 
 @login_required
@@ -181,14 +171,19 @@ def edit_post(request, post_id):
 
     """
     post = get_post(post_id)
-    form = PostForm(instance=post)
+    # form = PostForm(instance=post)
     if request.method == 'POST':
-
-        post.content = request.POST.get('content', '')
-        post.save()
+        form = PostForm(request.POST, instance=post)
+        if form.is_valid():
+            form.author = request.user
+            form.updated_at = datetime.now()
+            print(form.cleaned_data)
+            form.save()
+            messages.success(request, 'Post Edited Successfully')
         return HttpResponseRedirect(reverse('post_detail',
                                             kwargs={'post_id': post_id}))
     else:
+        form = PostForm(instance=post)
         return render(request,
                       'blog/edit_post.html',
                       {'post': post, 'form': form})

--- a/home/templates/home/read_more.html
+++ b/home/templates/home/read_more.html
@@ -9,9 +9,9 @@
         <h3>Understanding Neurodiversity:</h3>
         <p>Neurodiversity refers to various brain differences and is not a diagnosis but an umbrella term encompassing individuals whose brains function differently than neurotypical individuals.</p>
         </div>
-        <div id="info-image">
-            <img src='../static/img/people-thinking.jpg' alt="Photo of mother and son">
-        </div>
+{#        <div id="info-image">#}
+            <img class="img-thumbnail" src='../static/img/people-thinking.jpg' alt="Photo of mother and son" width="300">
+{#        </div>#}
     </div>
     <div id="practical-info" class="image-left">
         <div id="practical-text">


### PR DESCRIPTION
Updates have been made to the blog application's forms, views, and templates to accommodate the post's title field. The PostForm has been updated to include the 'title' field. Also, the 'add_post' and 'edit_post' views have been refactored to handle the updated PostForm and to improve the form validation process. Prettified read_more and post_detail templates, and updated edit_post to work correctly.