### PR TITLE
Restrict post reactions to authenticated users

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -222,6 +222,9 @@ def edit_comment(request, comment_id):
 
 def reaction_add(request, post_id, reaction_type):
     post = get_post(post_id)
+    if not request.user.is_authenticated:
+        messages.warning(request,'You are not logged in to add reactions.!')
+        return HttpResponseRedirect(reverse('blog_home'))
     if Reactions.objects.filter(post=post, user=request.user).exists():
         existing_reaction = Reactions.objects.get(post=post, user=request.user)
         existing_reaction.reaction_type = reaction_type


### PR DESCRIPTION
Added a condition in the 'reaction_add' function to check if a user is authenticated before they add reactions to a post. If a user is not logged in, a warning message is displayed and they are redirected to the blog homepage.